### PR TITLE
Add support for alibaba/qwen3-coder-plus model

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -288,6 +288,7 @@ LITELLM_CHAT_PROVIDERS = [
     "oci",
     "morph",
     "lambda_ai",
+    "alibaba",
 ]
 
 LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS = [
@@ -420,6 +421,7 @@ openai_compatible_endpoints: List = [
     "https://api.morphllm.com/v1",
     "https://api.lambda.ai/v1",
     "https://api.hyperbolic.xyz/v1",
+    "https://portal.qwen.ai/v1",
 ]
 
 

--- a/litellm/llms/alibaba/chat/transformation.py
+++ b/litellm/llms/alibaba/chat/transformation.py
@@ -1,0 +1,77 @@
+"""
+Translates from OpenAI's `/v1/chat/completions` to Alibaba Qwen's `/v1/chat/completions`
+"""
+
+from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
+
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    handle_messages_with_content_list_to_str_conversion,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllMessageValues
+
+from ...openai.chat.gpt_transformation import OpenAIGPTConfig
+
+
+class AlibabaChatConfig(OpenAIGPTConfig):
+    @overload
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
+        ...
+
+    @overload
+    def _transform_messages(
+        self,
+        messages: List[AllMessageValues],
+        model: str,
+        is_async: Literal[False] = False,
+    ) -> List[AllMessageValues]:
+        ...
+
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str, is_async: bool = False
+    ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
+        """
+        Alibaba Qwen API follows OpenAI format. Handle content in list format by converting to string.
+        """
+        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        if is_async:
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=True
+            )
+        else:
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=False
+            )
+
+    def _get_openai_compatible_provider_info(
+        self, api_base: Optional[str], api_key: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        api_base = (
+            api_base
+            or get_secret_str("ALIBABA_API_BASE")
+            or "https://portal.qwen.ai/v1"
+        )  # type: ignore
+        dynamic_api_key = api_key or get_secret_str("ALIBABA_API_KEY")
+        return api_base, dynamic_api_key
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        """
+        If api_base is not provided, use the default Alibaba Qwen /chat/completions endpoint.
+        """
+        if not api_base:
+            api_base = "https://portal.qwen.ai/v1"
+
+        if not api_base.endswith("/chat/completions"):
+            api_base = f"{api_base}/chat/completions"
+
+        return api_base

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2308,6 +2308,7 @@ class LlmProviders(str, Enum):
     MORPH = "morph"
     LAMBDA_AI = "lambda_ai"
     DEEPSEEK = "deepseek"
+    ALIBABA = "alibaba"
     SAMBANOVA = "sambanova"
     MARITALK = "maritalk"
     VOYAGE = "voyage"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19891,5 +19891,18 @@
         "metadata": {
             "notes": "DALL-E 2 via AI/ML API - Reliable text-to-image generation"
         }
+    },
+    "alibaba/qwen3-coder-plus": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "alibaba",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "source": "https://portal.qwen.ai/"
     }
 }


### PR DESCRIPTION
## Summary
- Add ALIBABA to LlmProviders enum in types/utils.py
- Create alibaba provider with OpenAI-compatible chat transformation
- Add alibaba to openai_compatible_providers and endpoints in constants.py
- Add alibaba/qwen3-coder-plus model configuration with proper pricing and capabilities

## Implementation Details
- Uses official Alibaba Qwen API endpoint: `https://portal.qwen.ai/v1`
- Follows OpenAI-compatible API format
- Supports function calling, tool choice, and reasoning capabilities
- Model configured with 131K input tokens, 8K output tokens
- Pricing: $0.001/1K input tokens, $0.005/1K output tokens

## Test plan
- Model can be used with `litellm.completion(model="alibaba/qwen3-coder-plus", ...)`
- API key should be set via `ALIBABA_API_KEY` environment variable
- API base can be customized via `ALIBABA_API_BASE` environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)